### PR TITLE
validator/beacon down alert only checks if beacon is down

### DIFF
--- a/less_10_validators.json
+++ b/less_10_validators.json
@@ -3001,7 +3001,7 @@
             {
             "evaluator": {
                 "params": [
-                1
+                0.9
                 ],
                 "type": "lt"
             },

--- a/less_10_validators.json
+++ b/less_10_validators.json
@@ -3024,7 +3024,7 @@
             {
             "evaluator": {
                 "params": [
-                1
+                0.9
                 ],
                 "type": "lt"
             },

--- a/less_10_validators.json
+++ b/less_10_validators.json
@@ -2995,32 +2995,55 @@
       }
     },
     {
-      "alert": {
+    "alert": {
         "alertRuleTags": {},
         "conditions": [
-          {
+            {
             "evaluator": {
-              "params": [
-                0.9
-              ],
-              "type": "lt"
+                "params": [
+                1
+                ],
+                "type": "lt"
             },
             "operator": {
-              "type": "and"
+                "type": "and"
             },
             "query": {
-              "params": [
+                "params": [
                 "A",
                 "5m",
                 "now"
-              ]
+                ]
             },
             "reducer": {
-              "params": [],
-              "type": "avg"
+                "params": [],
+                "type": "avg"
             },
             "type": "query"
-          }
+            },
+            {
+            "evaluator": {
+                "params": [
+                1
+                ],
+                "type": "lt"
+            },
+            "operator": {
+                "type": "or"
+            },
+            "query": {
+                "params": [
+                "B",
+                "5m",
+                "now"
+                ]
+            },
+            "reducer": {
+                "params": [],
+                "type": "avg"
+            },
+            "type": "query"
+            }
         ],
         "executionErrorState": "alerting",
         "for": "5m",


### PR DESCRIPTION
Currently, the validator/beacon down alert does not check if the validator is down. I fixed this by adding an OR condition to the alert that also checks the state of the validator.